### PR TITLE
Add Render.com deployment config and block indexing on test site

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -39,8 +39,8 @@ COPY --from=build /rails /rails
 
 RUN groupadd --system --gid 1000 rails && \
     useradd rails --uid 1000 --gid 1000 --create-home --shell /bin/bash && \
-    mkdir -p db storage log tmp/pids tmp/sockets public/uploads && \
-    chown -R rails:rails db storage log tmp public/uploads
+    mkdir -p db data storage log tmp/pids tmp/sockets public/uploads && \
+    chown -R rails:rails db data storage log tmp public/uploads
 
 USER 1000:1000
 

--- a/app/controllers/robots_controller.rb
+++ b/app/controllers/robots_controller.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+class RobotsController < ActionController::Base
+  def show
+    render plain: robots_content, content_type: 'text/plain'
+  end
+
+  private
+
+  def robots_content
+    if ENV['DISALLOW_INDEXING'].present?
+      <<~ROBOTS
+        User-agent: *
+        Disallow: /
+      ROBOTS
+    else
+      <<~ROBOTS
+        User-agent: *
+        Allow: /
+        Disallow: /admin
+
+        Sitemap: https://tehnoholod.ru/sitemap.xml
+      ROBOTS
+    end
+  end
+end

--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -3,6 +3,8 @@ html lang="ru"
   head
     meta charset="utf-8"
     = display_meta_tags site: 'Технохолод', separator: '|', reverse: true
+    - if ENV['DISALLOW_INDEXING'].present?
+      meta name="robots" content="noindex, nofollow"
     link rel="shortcut icon" href="favicon.ico" type="image/x-icon"
     = tag(:link, rel: 'canonical', href: request.original_url.split('?').first)
     meta name="yandex-verification" content="bb996f2cc0ab9dc5"

--- a/bin/docker-entrypoint
+++ b/bin/docker-entrypoint
@@ -5,6 +5,16 @@ if [ -z "${LD_PRELOAD+x}" ] && [ -f /usr/lib/*/libjemalloc.so.2 ]; then
   export LD_PRELOAD="$(echo /usr/lib/*/libjemalloc.so.2)"
 fi
 
+# Prepare persistent data directory (Render disk mount)
+if [ -d /rails/data ]; then
+  mkdir -p /rails/data/uploads
+  # Symlink uploads to persistent disk if not already linked
+  if [ ! -L /rails/public/uploads ]; then
+    rm -rf /rails/public/uploads
+    ln -sf /rails/data/uploads /rails/public/uploads
+  fi
+fi
+
 # Run pending migrations automatically on deploy
 if [ "${RAILS_ENV}" = "production" ]; then
   ./bin/rails db:prepare

--- a/config/database.yml
+++ b/config/database.yml
@@ -13,4 +13,4 @@ test:
 
 production:
   <<: *default
-  database: db/production.sqlite3
+  database: <%= ENV.fetch('DATABASE_PATH', 'db/production.sqlite3') %>

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -42,13 +42,17 @@ Rails.application.configure do
   # Do not dump schema after migrations.
   config.active_record.dump_schema_after_migration = false
 
-  config.action_mailer.delivery_method = :smtp
-  config.action_mailer.smtp_settings = {
-    address: 'smtp.gmail.com',
-    port: 587,
-    enable_starttls_auto: true,
-    user_name: 'efelikanfuzin',
-    password: ENV.fetch('SMTP_PASSWORD'),
-    authentication: 'login'
-  }
+  if ENV['SMTP_PASSWORD'].present?
+    config.action_mailer.delivery_method = :smtp
+    config.action_mailer.smtp_settings = {
+      address: 'smtp.gmail.com',
+      port: 587,
+      enable_starttls_auto: true,
+      user_name: 'efelikanfuzin',
+      password: ENV['SMTP_PASSWORD'],
+      authentication: 'login'
+    }
+  else
+    config.action_mailer.delivery_method = :test
+  end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,6 @@
 Rails.application.routes.draw do
+  get '/robots.txt', to: 'robots#show', as: :robots
+
   mount Ckeditor::Engine => '/ckeditor'
   authenticate :user do
     namespace :admin do

--- a/config/sitemap.rb
+++ b/config/sitemap.rb
@@ -1,3 +1,5 @@
+return if ENV['DISALLOW_INDEXING'].present?
+
 SitemapGenerator::Sitemap.default_host = 'https://tehnoholod.ru'
 SitemapGenerator::Sitemap.compress = false
 

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,5 +1,0 @@
-User-agent: *
-Allow: /
-Disallow: /admin
-
-Sitemap: https://tehnoholod.ru/sitemap.xml

--- a/render.yaml
+++ b/render.yaml
@@ -1,0 +1,29 @@
+# Render Blueprint — https://render.com/docs/blueprint-spec
+# Deploy: connect this repo on Render Dashboard or use the Deploy to Render button.
+
+services:
+  - type: web
+    name: tehnoholod
+    runtime: docker
+    plan: free
+    dockerfilePath: ./Dockerfile
+    healthCheckPath: /
+    envVars:
+      - key: RAILS_ENV
+        value: production
+      - key: RAILS_LOG_TO_STDOUT
+        value: "1"
+      - key: RAILS_SERVE_STATIC_FILES
+        value: "1"
+      - key: SECRET_KEY_BASE
+        generateValue: true
+      - key: DISALLOW_INDEXING
+        value: "true"
+      - key: DATABASE_PATH
+        value: /rails/data/production.sqlite3
+      - key: SMTP_PASSWORD
+        value: ""
+    disk:
+      name: tehnoholod-data
+      mountPath: /rails/data
+      sizeGB: 1


### PR DESCRIPTION
- Add render.yaml blueprint for free-tier Docker deployment with persistent disk
- Replace static robots.txt with dynamic controller (DISALLOW_INDEXING env var)
- Add noindex meta tag in layout when DISALLOW_INDEXING is set
- Skip sitemap generation when DISALLOW_INDEXING is set
- Make SMTP_PASSWORD optional (fallback to :test delivery on Render)
- Support DATABASE_PATH env var for persistent disk SQLite storage
- Symlink uploads to persistent disk in docker-entrypoint

https://claude.ai/code/session_01NHk3qX4EAHkuP2Pf2bsrD1