### PR TITLE
Add nodejs to Docker build stage for asset compilation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@ ENV RAILS_ENV="production" \
 FROM base AS build
 
 RUN apt-get update -qq && \
-    apt-get install --no-install-recommends -y build-essential git libsqlite3-dev pkg-config && \
+    apt-get install --no-install-recommends -y build-essential git libsqlite3-dev pkg-config nodejs && \
     rm -rf /var/lib/apt/lists /var/cache/apt/archives
 
 COPY Gemfile Gemfile.lock ./


### PR DESCRIPTION
The terser gem depends on execjs which requires a JavaScript runtime.
Without nodejs installed in the build stage, rails assets:precompile fails.

https://claude.ai/code/session_017rT3VRszoTF4padY2WLLCp