### PR TITLE
Add selectize-rails gem to fix asset compilation error

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -25,6 +25,7 @@ gem 'slim-rails'
 gem 'sprockets-rails'
 gem 'sassc-rails'
 gem 'jquery-rails'
+gem 'selectize-rails'
 gem 'terser'
 gem 'kamal', require: false
 gem 'whenever', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -339,6 +339,7 @@ GEM
       sprockets-rails
       tilt
     securerandom (0.4.1)
+    selectize-rails (0.12.6)
     sitemap_generator (6.3.0)
       builder (~> 3.0)
     slim (5.2.1)
@@ -433,6 +434,7 @@ DEPENDENCIES
   rubocop
   rubocop-rails
   sassc-rails
+  selectize-rails
   sitemap_generator
   slim-rails
   sprockets-rails


### PR DESCRIPTION
The administrate JS manifest (administrate/application.js) requires
'selectize' but the gem was missing from the Gemfile, causing
Sprockets::FileNotFound during asset compilation.

https://claude.ai/code/session_01U7gFsnJVBLgh524ykyuvuX