### PR TITLE
Remove unused moment.js and datetime_picker dependencies

### DIFF
--- a/app/assets/javascripts/administrate/application.js
+++ b/app/assets/javascripts/administrate/application.js
@@ -1,6 +1,4 @@
 //= require jquery
 //= require jquery_ujs
 //= require selectize
-//= require moment
-//= require datetime_picker
 //= require_tree .

--- a/app/assets/javascripts/administrate/components/date_time_picker.js
+++ b/app/assets/javascripts/administrate/components/date_time_picker.js
@@ -1,6 +1,0 @@
-$(function () {
-  $(".datetimepicker").datetimepicker({
-    debug: false,
-    format: "YYYY-MM-DD HH:mm:ss",
-  });
-});


### PR DESCRIPTION
The administrate asset manifest required 'moment' and 'datetime_picker'
libraries that were never installed (no gem, vendor file, or npm package).
The datetimepicker component is not used in any admin views or dashboards.

Removes the requires from the manifest and deletes the unused
date_time_picker.js component file.

Fixes: Sprockets::FileNotFound for 'moment'

https://claude.ai/code/session_013SkMB6vcsPP7zm7piDDBnH