### PR TITLE
Fix deploy permission error: stop creating /rails/data in Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -39,8 +39,8 @@ COPY --from=build /rails /rails
 
 RUN groupadd --system --gid 1000 rails && \
     useradd rails --uid 1000 --gid 1000 --create-home --shell /bin/bash && \
-    mkdir -p db data storage log tmp/pids tmp/sockets public/uploads && \
-    chown -R rails:rails db data storage log tmp public/uploads
+    mkdir -p db storage log tmp/pids tmp/sockets public/uploads && \
+    chown -R rails:rails db storage log tmp public/uploads
 
 USER 1000:1000
 


### PR DESCRIPTION
The Dockerfile was creating a /rails/data directory, which caused the
Render-specific entrypoint code to execute during Kamal deployments.
This tried to rm -rf the volume-mounted /rails/public/uploads as a
non-root user, resulting in "Permission denied".

The /rails/data directory only needs to exist on Render (via disk mount),
not in the image itself. Removing it from mkdir/chown prevents the
entrypoint from incorrectly entering the Render code path on Kamal.

https://claude.ai/code/session_01KVRZXVCqjR7AuLzJnU6AXr