### PR TITLE
Fix missing secret_key_base for production environment

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -1,6 +1,9 @@
 Rails.application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
 
+  # Read secret_key_base from environment variable (required for production).
+  config.secret_key_base = ENV["SECRET_KEY_BASE"]
+
   # Code is not reloaded between requests.
   config.enable_reloading = false
   config.log_level = :warn

--- a/config/secrets.yml
+++ b/config/secrets.yml
@@ -19,5 +19,4 @@ test:
 # Do not keep production secrets in the repository,
 # instead read values from the environment.
 production:
-  secret_token: 26e984031448df073dd0cad53a022358eaf5fafcf28f6697e602d1370ac02a9c6c968722f9d1d12625ddfb3e53be0ae6385551c923d2661fdb4a794e95849ec1
-  secret_key_base: 241fb64fb848d48c97aac468ab595cdd99e8753504df9afe0d82dd905f83b5510f314c331194a3fe7238164e805531474cb0ef874a99f4d93645ca5bf8015f85
+  secret_key_base: <%= ENV["SECRET_KEY_BASE"] %>


### PR DESCRIPTION
Rails 8.0 no longer loads config/secrets.yml by default, so the
hardcoded production secret_key_base was never read. Explicitly set
config.secret_key_base from the SECRET_KEY_BASE environment variable
in production.rb, and update secrets.yml to reference the env var
instead of storing secrets in version control.

https://claude.ai/code/session_01RjGB5gxRKoJrGSDnod8opC