### PR TITLE
Auto-generate SECRET_KEY_BASE when not provided via environment

### DIFF
--- a/bin/docker-entrypoint
+++ b/bin/docker-entrypoint
@@ -5,6 +5,11 @@ if [ -z "${LD_PRELOAD+x}" ] && [ -f /usr/lib/*/libjemalloc.so.2 ]; then
   export LD_PRELOAD="$(echo /usr/lib/*/libjemalloc.so.2)"
 fi
 
+# Generate SECRET_KEY_BASE if not set (e.g. Render free service without blueprint)
+if [ -z "${SECRET_KEY_BASE}" ]; then
+  export SECRET_KEY_BASE="$(openssl rand -hex 64)"
+fi
+
 # Prepare persistent data directory (Render disk mount)
 if [ -d /rails/data ]; then
   mkdir -p /rails/data/uploads


### PR DESCRIPTION
When deploying to Render as a regular free service (not via blueprint),
the render.yaml is not used so SECRET_KEY_BASE is never auto-generated.
This causes Rails to fail at boot. Generate it in docker-entrypoint as
a fallback using openssl.

https://claude.ai/code/session_013UaqCrHtJCweknF9iezZEH