### PR TITLE
Fix undefined $blue variable in _pagination.scss

### DIFF
--- a/app/assets/stylesheets/_pagination.scss
+++ b/app/assets/stylesheets/_pagination.scss
@@ -1,3 +1,5 @@
+$blue: #2563eb !default;
+
 // ─── Modern pagination ────────────────────────────────────────────────────────
 .pagination {
   display: flex;


### PR DESCRIPTION
Add $blue: #2563eb !default; at the top of the partial so SassC can
compile it standalone without depending on the import order in
application.css.scss.

https://claude.ai/code/session_01NTwLfUgZpcxFVu8A7YBSdN